### PR TITLE
Update typo in bin/setup command

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -34,6 +34,6 @@ FileUtils.chdir APP_ROOT do
   unless ARGV.include?('--skip-server')
     puts "\n== Restarting application server =="
     STDOUT.flush # flush the output before exec(2) so that it displays
-    exec 'bin/rail restart'
+    exec 'bin/rails restart'
   end
 end


### PR DESCRIPTION
There is a typo in the `bin/setup` file, where `rail` is called instead of `rails`. Updated the code to use rails

Change `bin/rail restart` command to `bin/rails restart`